### PR TITLE
Add support for isoDate, isoDuration, uuid, guid string formats

### DIFF
--- a/lib/parser_base.js
+++ b/lib/parser_base.js
@@ -230,6 +230,13 @@ class JoiJsonSchemaParser {
         case 'regex':
           fieldSchema.pattern = rule[ruleArgFieldName].pattern.source
           break
+        case 'isoDate':
+          fieldSchema.format = 'date-time'
+          break
+        case 'uuid':
+        case 'guid':
+          fieldSchema.format = 'uuid'
+          break
         default:
           break
       }

--- a/lib/parser_v16.js
+++ b/lib/parser_v16.js
@@ -132,6 +132,16 @@ class JoiJsonSchemaParser extends ParserBase {
           }
           fieldSchema.pattern = regex
           break
+        case 'isoDate':
+          fieldSchema.format = 'date-time'
+          break
+        case 'isoDuration':
+          fieldSchema.format = 'duration'
+          break
+        case 'uuid':
+        case 'guid':
+          fieldSchema.format = 'uuid'
+          break
         default:
           break
       }


### PR DESCRIPTION
According to https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.1.md#data-types `date-time`, `uuid` and `email` (which is already supported by `joi-to-json`) can be used despite not being defined by the spec. I have also thrown in convertion of `isoDuration` to `duration` which is covered by `ajv` with `ajv-formats` (which is what I use to do JSON Schema based validation).