### PR TITLE
fix: number enum are filtered

### DIFF
--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -101,7 +101,7 @@ class JoiJsonSchemaParser {
     }
 
     const enumList = _.filter(fieldDefn[this.enumFieldName], (item) => {
-      return !_.isEmpty(item)
+      return _.isNumber(item) ? item : !_.isEmpty(item)
     })
     return _.isEmpty(enumList) ? undefined : enumList
   }


### PR DESCRIPTION
like this enum shouldn't be filtered
```ts
 Joi.object({
    code: Joi.string()
      .valid([1, 2, 3])
      .required(),
  });
```