### PR TITLE
Add support for JSON schema's const option

### DIFF
--- a/fixtures/joi-obj-12.js
+++ b/fixtures/joi-obj-12.js
@@ -16,6 +16,7 @@ module.exports = joi.object().keys({
   email: joi.string().email(),
   ip: joi.string().ip({ version: ['ipv4', 'ipv6'] }),
   hostname: joi.string().hostname().insensitive(),
+  type: joi.string().valid('user'),
   gender: joi.string().valid('Male', 'Female', '', null).default('Male'),
   genderSpecific: joi.when('gender', {
     is: 'Female',

--- a/fixtures/joi-obj-13.js
+++ b/fixtures/joi-obj-13.js
@@ -16,6 +16,7 @@ module.exports = joi.object().keys({
   email: joi.string().email(),
   ip: joi.string().ip({ version: ['ipv4', 'ipv6'] }),
   hostname: joi.string().hostname().insensitive(),
+  type: joi.string().valid('user'),
   gender: joi.string().valid('Male', 'Female', '', null).default('Male'),
   genderSpecific: joi.when('gender', {
     is: 'Female',

--- a/fixtures/joi-obj-14.js
+++ b/fixtures/joi-obj-14.js
@@ -16,6 +16,7 @@ module.exports = joi.object().keys({
   email: joi.string().email(),
   ip: joi.string().ip({ version: ['ipv4', 'ipv6'] }),
   hostname: joi.string().hostname().insensitive(),
+  type: joi.string().valid('user'),
   gender: joi.string().valid('Male', 'Female', '', null).default('Male'),
   genderSpecific: joi.when('gender', {
     is: 'Female',

--- a/fixtures/joi-obj-15.js
+++ b/fixtures/joi-obj-15.js
@@ -16,6 +16,7 @@ module.exports = joi.object().keys({
   email: joi.string().email(),
   ip: joi.string().ip({ version: ['ipv4', 'ipv6'] }),
   hostname: joi.string().hostname().insensitive(),
+  type: joi.string().valid('user'),
   gender: joi.string().valid('Male', 'Female', '', null).default('Male'),
   genderSpecific: joi.when('gender', {
     is: 'Female',

--- a/fixtures/joi-obj-16.js
+++ b/fixtures/joi-obj-16.js
@@ -21,6 +21,7 @@ module.exports = joi.object().keys({
   email: joi.string().email(),
   ip: joi.string().ip({ version: ['ipv4', 'ipv6'] }),
   hostname: joi.string().hostname().insensitive(),
+  type: joi.string().valid('user'),
   gender: joi.string().valid('Male', 'Female', '', null).default('Male'),
   genderSpecific: joi.when('gender', {
     is: 'Female',

--- a/fixtures/joi-obj-17.js
+++ b/fixtures/joi-obj-17.js
@@ -21,6 +21,7 @@ module.exports = joi.object().keys({
   email: joi.string().email(),
   ip: joi.string().ip({ version: ['ipv4', 'ipv6'] }),
   hostname: joi.string().hostname().insensitive(),
+  type: joi.string().valid('user'),
   gender: joi.string().valid('Male', 'Female', '', null).default('Male'),
   genderSpecific: joi.when('gender', {
     is: 'Female',

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -115,9 +115,16 @@ class JoiJsonSchemaParser {
     return _.get(fieldDefn, 'flags.default')
   }
 
+  _getConst(fieldDefn) {
+    const enumList = fieldDefn[this.enumFieldName]
+    if (fieldDefn.flags && fieldDefn.flags.only && enumList.length === 1) {
+      return enumList[0]
+    }
+  }
+
   _getEnum(fieldDefn) {
     const enumList = fieldDefn[this.enumFieldName]
-    if (fieldDefn.flags && fieldDefn.flags.only && !_.isEmpty(enumList)) {
+    if (fieldDefn.flags && fieldDefn.flags.only && enumList.length > 1) {
       return _.uniq(enumList)
     }
   }
@@ -141,6 +148,7 @@ class JoiJsonSchemaParser {
     this._setIfNotEmpty(fieldSchema, 'examples', this._getFieldExample(fieldDefn))
     this._setIfNotEmpty(fieldSchema, 'description', this._getFieldDescription(fieldDefn))
     this._setIfNotEmpty(fieldSchema, 'default', this._getDefaultValue(fieldDefn))
+    this._setIfNotEmpty(fieldSchema, 'const', this._getConst(fieldDefn))
     this._setIfNotEmpty(fieldSchema, 'enum', this._getEnum(fieldDefn))
   }
 

--- a/lib/parsers/open-api.js
+++ b/lib/parsers/open-api.js
@@ -53,6 +53,10 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
       schema.schemas = definitions
     }
 
+    if (fullSchema.const) {
+      schema.enum = [fullSchema.const]
+    }
+
     return schema
   }
 

--- a/outputs/json-draft-04/base.json
+++ b/outputs/json-draft-04/base.json
@@ -51,6 +51,10 @@
       "type": "string",
       "format": "hostname"
     },
+    "type": {
+      "type": "string",
+      "const": "user"
+    },
     "gender": {
       "type": [
         "string",

--- a/outputs/json-draft-04/joi-obj-16.json
+++ b/outputs/json-draft-04/joi-obj-16.json
@@ -76,6 +76,10 @@
           "type": "string",
           "format": "hostname"
         },
+        "type": {
+          "type": "string",
+          "const": "user"
+        },
         "gender": {
           "type": [
             "string",

--- a/outputs/json-draft-04/joi-obj-17.json
+++ b/outputs/json-draft-04/joi-obj-17.json
@@ -76,6 +76,10 @@
           "type": "string",
           "format": "hostname"
         },
+        "type": {
+          "type": "string",
+          "const": "user"
+        },
         "gender": {
           "type": [
             "string",

--- a/outputs/json-draft-2019-09/base.json
+++ b/outputs/json-draft-2019-09/base.json
@@ -51,6 +51,10 @@
       "type": "string",
       "format": "hostname"
     },
+    "type": {
+      "type": "string",
+      "const": "user"
+    },
     "gender": {
       "type": [
         "string",

--- a/outputs/json-draft-2019-09/joi-obj-16.json
+++ b/outputs/json-draft-2019-09/joi-obj-16.json
@@ -76,6 +76,10 @@
           "type": "string",
           "format": "hostname"
         },
+        "type": {
+          "type": "string",
+          "const": "user"
+        },
         "gender": {
           "type": [
             "string",

--- a/outputs/json-draft-2019-09/joi-obj-17.json
+++ b/outputs/json-draft-2019-09/joi-obj-17.json
@@ -76,6 +76,10 @@
           "type": "string",
           "format": "hostname"
         },
+        "type": {
+          "type": "string",
+          "const": "user"
+        },
         "gender": {
           "type": [
             "string",

--- a/outputs/json/base.json
+++ b/outputs/json/base.json
@@ -51,6 +51,10 @@
       "type": "string",
       "format": "hostname"
     },
+    "type": {
+      "type": "string",
+      "const": "user"
+    },
     "gender": {
       "type": [
         "string",

--- a/outputs/json/joi-obj-16.json
+++ b/outputs/json/joi-obj-16.json
@@ -76,6 +76,10 @@
           "type": "string",
           "format": "hostname"
         },
+        "type": {
+          "type": "string",
+          "const": "user"
+        },
         "gender": {
           "type": [
             "string",

--- a/outputs/json/joi-obj-17.json
+++ b/outputs/json/joi-obj-17.json
@@ -74,6 +74,10 @@
           "type": "string",
           "format": "hostname"
         },
+        "type": {
+          "type": "string",
+          "const": "user"
+        },
         "gender": {
           "type": [
             "string",

--- a/outputs/open-api/base.json
+++ b/outputs/open-api/base.json
@@ -52,6 +52,10 @@
       "nullable": true,
       "type": "string"
     },
+    "type": {
+      "enum": ["user"],
+      "type": "string"
+    },
     "gender": {
       "default": "Male",
       "enum": [

--- a/outputs/open-api/joi-obj-16.json
+++ b/outputs/open-api/joi-obj-16.json
@@ -83,6 +83,10 @@
           "nullable": true,
           "type": "string"
         },
+        "type": {
+          "enum": ["user"],
+          "type": "string"
+        },
         "gender": {
           "default": "Male",
           "enum": [

--- a/outputs/open-api/joi-obj-17.json
+++ b/outputs/open-api/joi-obj-17.json
@@ -83,6 +83,10 @@
           "nullable": true,
           "type": "string"
         },
+        "type": {
+          "enum": ["user"],
+          "type": "string"
+        },
         "gender": {
           "default": "Male",
           "enum": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-to-json",
-  "version": "2.3.0",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -805,18 +805,18 @@
       }
     },
     "@sideway/address": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
-      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
       "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
-          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
           "dev": true
         }
       }
@@ -2710,9 +2710,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.2.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
-          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+          "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
           "dev": true
         },
         "@hapi/topo": {


### PR DESCRIPTION
Joi schemas that use `.valid` with a single argument are effectively defining constants, this commit makes the generated JSON schema reflect this by using the `const` property as opposed to the `enum` property in these cases. 

The use case that triggered this PR is that `const` works better with Monaco's JSON IntelliSense in some cases, like the following:
```js
const male = Joi.object({ gender: Joi.string().valid('male'), attributes: maleAttributesSchema });
const female =  Joi.object({ gender: Joi.string().valid('female'), attributes: femaleAttributesSchema });

const person = Joi.alternatives().try(male, female);
```