### PR TITLE
Add support for switch conditions

### DIFF
--- a/fixtures/joi-obj-16.js
+++ b/fixtures/joi-obj-16.js
@@ -28,6 +28,16 @@ module.exports = joi.object().keys({
     then: joi.number().valid(0, 1, 2).required(),
     otherwise: joi.link('#unifiedString')
   }),
+  genderSpecificSwitch: joi.when('gender', [
+    {
+      is: 'Male',
+      then: joi.string()
+    },
+    {
+      is: 'Female',
+      then: joi.number()
+    }
+  ]),
   height: joi.link('#unit').shared(unitSchema),
   heightRank: joi.alternatives().conditional('height', {
     switch: [

--- a/fixtures/joi-obj-17.js
+++ b/fixtures/joi-obj-17.js
@@ -28,6 +28,16 @@ module.exports = joi.object().keys({
     then: joi.number().valid(0, 1, 2).required(),
     otherwise: joi.link('#unifiedString')
   }),
+  genderSpecificSwitch: joi.when('gender', [
+    {
+      is: 'Male',
+      then: joi.string()
+    },
+    {
+      is: 'Female',
+      then: joi.number()
+    }
+  ]),
   maleSpecific: joi.alternatives().conditional('gender', {
     is: 'Male',
     then: joi.string().not().empty().required(),

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -420,14 +420,30 @@ class JoiJsonSchemaParser {
     }
 
     if (joiSpec.whens) {
-      const condition = joiSpec.whens[0]
       schema.oneOf = []
+
+      const condition = joiSpec.whens[0]
+
+      if (condition.switch) {
+        for (const switchCondition of condition.switch) {
+          if (switchCondition.then) {
+            schema.oneOf.push(this.parse(switchCondition.then, definitions, level + 1))
+          }
+
+          if (switchCondition.otherwise) {
+            schema.oneOf.push(this.parse(switchCondition.otherwise, definitions, level + 1))
+          }
+        }
+      }
+
       if (condition.then) {
         schema.oneOf.push(this.parse(condition.then, definitions, level + 1))
       }
+
       if (condition.otherwise) {
         schema.oneOf.push(this.parse(condition.otherwise, definitions, level + 1))
       }
+
       delete schema.type
       return
     }

--- a/outputs/json-draft-04/joi-obj-16.json
+++ b/outputs/json-draft-04/joi-obj-16.json
@@ -108,6 +108,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "height": {
           "$ref": "#/definitions/unit"
         },

--- a/outputs/json-draft-04/joi-obj-17.json
+++ b/outputs/json-draft-04/joi-obj-17.json
@@ -108,6 +108,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "height": {
           "$ref": "#/definitions/unit"
         },

--- a/outputs/json-draft-2019-09/joi-obj-16.json
+++ b/outputs/json-draft-2019-09/joi-obj-16.json
@@ -108,6 +108,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "height": {
           "$ref": "#/$defs/unit"
         },

--- a/outputs/json-draft-2019-09/joi-obj-17.json
+++ b/outputs/json-draft-2019-09/joi-obj-17.json
@@ -108,6 +108,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "height": {
           "$ref": "#/$defs/unit"
         },

--- a/outputs/json/joi-obj-16.json
+++ b/outputs/json/joi-obj-16.json
@@ -108,6 +108,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+             {
+               "type": "string"
+             },
+             {
+               "type": "number"
+             }
+           ]
+         },
         "height": {
           "$ref": "#/$defs/unit"
         },

--- a/outputs/json/joi-obj-17.json
+++ b/outputs/json/joi-obj-17.json
@@ -106,6 +106,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "height": {
           "$ref": "#/$defs/unit"
         },

--- a/outputs/open-api/joi-obj-16.json
+++ b/outputs/open-api/joi-obj-16.json
@@ -113,6 +113,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "guid": {
           "format": "uuid",
           "type": "string"

--- a/outputs/open-api/joi-obj-17.json
+++ b/outputs/open-api/joi-obj-17.json
@@ -113,6 +113,16 @@
             }
           ]
         },
+        "genderSpecificSwitch":  {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
         "guid": {
           "format": "uuid",
           "type": "string"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-to-json",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Adds support for Joi's `switch` conditions, e.g.:
```js
  genderSpecificSwitch: joi.when('gender', [
    {
      is: 'Male',
      then: joi.string()
    },
    {
      is: 'Female',
      then: joi.number()
    }
  ]),

  genderSpecificSwitch: joi.when('gender', {
    switch: [
      {
        is: 'Male',
        then: joi.string()
      },
      {
        is: 'Female',
        then: joi.number()
      }
    ]
  }),
  ```