### PR TITLE
Postitive/negative number

### DIFF
--- a/outputs-conversion/number/negative.json
+++ b/outputs-conversion/number/negative.json
@@ -1,5 +1,6 @@
 {
   "type": "number",
+  "exclusiveMaximum": 0.0,
   "rules": [
     {
       "name": "sign",

--- a/outputs-conversion/number/positive.json
+++ b/outputs-conversion/number/positive.json
@@ -1,5 +1,6 @@
 {
   "type": "number",
+  "exclusiveMinimum": 0.0,
   "rules": [
     {
       "name": "sign",


### PR DESCRIPTION
This is for https://github.com/kenspirit/joi-to-json/issues/47

I noticed the positive/negative sign rules, but the parser I'm using (vscode-yaml) doesn't seem to support that rule because it isn't catching violations. Using `exclusiveMinimum` and `exclusiveMaximum` works, though. Any chance you could include both for better coverage?