### PR TITLE
Copy meta attributes to shared definitions when creating a `$ref`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dist
 .tern-port
 
 .vscode
+.DS_Store

--- a/lib/parsers/json-draft-2019-09.js
+++ b/lib/parsers/json-draft-2019-09.js
@@ -8,16 +8,8 @@ class JoiJsonDraftSchemaParser extends JoiJsonSchemaParser {
     }, opts))
   }
 
-  _copyMetasToSchema(joiSpec, schema) {
-    if (!_.isEmpty(joiSpec.metas)) {
-      _.each(joiSpec.metas, meta => {
-        _.each(meta, (value, key) => {
-          if (key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
-            schema[key] = value
-          }
-        })
-      })
-    }
+  _isKnownMetaKey(key) {
+    return key === 'deprecated' || key === 'readOnly' || key === 'writeOnly'
   }
 }
 

--- a/lib/parsers/json-draft-2019-09.js
+++ b/lib/parsers/json-draft-2019-09.js
@@ -11,6 +11,14 @@ class JoiJsonDraftSchemaParser extends JoiJsonSchemaParser {
   parse(joiSpec, definitions = {}, level = 0) {
     const schema = super.parse(joiSpec, definitions, level)
 
+    if (!schema.$ref) {
+      this._copyMetasToSchema(joiSpec, schema)
+    }
+
+    return schema
+  }
+
+  _copyMetasToSchema(joiSpec, schema) {
     if (!_.isEmpty(joiSpec.metas)) {
       _.each(joiSpec.metas, meta => {
         _.each(meta, (value, key) => {
@@ -20,8 +28,14 @@ class JoiJsonDraftSchemaParser extends JoiJsonSchemaParser {
         })
       })
     }
+  }
 
-    return schema
+  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
+    this._copyMetasToSchema(joiSpec, schema)
+    definitions[schemaId] = schema
+    return {
+      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
+    }
   }
 }
 

--- a/lib/parsers/json-draft-2019-09.js
+++ b/lib/parsers/json-draft-2019-09.js
@@ -8,16 +8,6 @@ class JoiJsonDraftSchemaParser extends JoiJsonSchemaParser {
     }, opts))
   }
 
-  parse(joiSpec, definitions = {}, level = 0) {
-    const schema = super.parse(joiSpec, definitions, level)
-
-    if (!schema.$ref) {
-      this._copyMetasToSchema(joiSpec, schema)
-    }
-
-    return schema
-  }
-
   _copyMetasToSchema(joiSpec, schema) {
     if (!_.isEmpty(joiSpec.metas)) {
       _.each(joiSpec.metas, meta => {
@@ -27,14 +17,6 @@ class JoiJsonDraftSchemaParser extends JoiJsonSchemaParser {
           }
         })
       })
-    }
-  }
-
-  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
-    this._copyMetasToSchema(joiSpec, schema)
-    definitions[schemaId] = schema
-    return {
-      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
     }
   }
 }

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -128,10 +128,7 @@ class JoiJsonSchemaParser {
 
     const schemaId = _.get(joiSpec, 'flags.id')
     if (schemaId) {
-      definitions[schemaId] = schema
-      schema = {
-        $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
-      }
+      schema = this._moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId)
     }
     if (level === 0 && !_.isEmpty(definitions)) {
       _.set(schema, `${this._getLocalSchemaBasePath().replace('#/', '').replace(/\//, '.')}`, definitions)
@@ -773,6 +770,13 @@ class JoiJsonSchemaParser {
     if (_.get(joiSpec, 'link.ref.type') === 'local') {
       schema.$ref = `${this._getLocalSchemaBasePath()}/${joiSpec.link.ref.path.join('/')}`
       delete schema.type
+    }
+  }
+
+  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
+    definitions[schemaId] = schema
+    return {
+      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
     }
   }
 }

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -75,9 +75,9 @@ const LOGICAL_OP_PARSER = {
  */
 function isJoiOverride(e) {
   return typeof e === 'object'
-         && e !== null
-         && Object.keys(e).length === 1
-         && e.override === true
+    && e !== null
+    && Object.keys(e).length === 1
+    && e.override === true
 }
 
 class JoiJsonSchemaParser {
@@ -131,7 +131,7 @@ class JoiJsonSchemaParser {
     const schemaId = _.get(joiSpec, 'flags.id')
     if (schemaId) {
       definitions[schemaId] = schema
-      schema =  {
+      schema = {
         $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
       }
     }
@@ -780,7 +780,7 @@ class JoiJsonSchemaParser {
 
   // _copyMetasToSchema is intended to be overridden by child parsers.
   // eslint-disable-next-line no-unused-vars
-  _copyMetasToSchema(joiSpec, schema) {}
+  _copyMetasToSchema(joiSpec, schema) { }
 }
 
 module.exports = JoiJsonSchemaParser

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -790,7 +790,8 @@ class JoiJsonSchemaParser {
     }
   }
 
-  // intended to be overridden by child parsers. By default no meta will be copied.
+  // Intended to be overridden by child parsers. By default no meta key will be
+  // is considered "known".
   // eslint-disable-next-line no-unused-vars
   _isKnownMetaKey(key) {
     return false

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -778,9 +778,23 @@ class JoiJsonSchemaParser {
     }
   }
 
-  // _copyMetasToSchema is intended to be overridden by child parsers.
+  _copyMetasToSchema(joiSpec, schema) {
+    if (!_.isEmpty(joiSpec.metas)) {
+      _.each(joiSpec.metas, meta => {
+        _.each(meta, (value, key) => {
+          if (this._isKnownMetaKey(key)) {
+            schema[key] = value
+          }
+        })
+      })
+    }
+  }
+
+  // intended to be overridden by child parsers. By default no meta will be copied.
   // eslint-disable-next-line no-unused-vars
-  _copyMetasToSchema(joiSpec, schema) { }
+  _isKnownMetaKey(key) {
+    return false
+  }
 }
 
 module.exports = JoiJsonSchemaParser

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -126,9 +126,14 @@ class JoiJsonSchemaParser {
       })
     }
 
+    this._copyMetasToSchema(joiSpec, schema)
+
     const schemaId = _.get(joiSpec, 'flags.id')
     if (schemaId) {
-      schema = this._moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId)
+      definitions[schemaId] = schema
+      schema =  {
+        $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
+      }
     }
     if (level === 0 && !_.isEmpty(definitions)) {
       _.set(schema, `${this._getLocalSchemaBasePath().replace('#/', '').replace(/\//, '.')}`, definitions)
@@ -773,12 +778,9 @@ class JoiJsonSchemaParser {
     }
   }
 
-  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
-    definitions[schemaId] = schema
-    return {
-      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
-    }
-  }
+  // _copyMetasToSchema is intended to be overridden by child parsers.
+  // eslint-disable-next-line no-unused-vars
+  _copyMetasToSchema(joiSpec, schema) {}
 }
 
 module.exports = JoiJsonSchemaParser

--- a/lib/parsers/open-api-3.1.js
+++ b/lib/parsers/open-api-3.1.js
@@ -23,16 +23,8 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
     return '#/components/schemas'
   }
 
-  _copyMetasToSchema(joiSpec, schema) {
-    if (!_.isEmpty(joiSpec.metas)) {
-      _.each(joiSpec.metas, meta => {
-        _.each(meta, (value, key) => {
-          if (key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
-            schema[key] = value
-          }
-        })
-      })
-    }
+  _isKnownMetaKey(key) {
+    return key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly'
   }
 }
 

--- a/lib/parsers/open-api-3.1.js
+++ b/lib/parsers/open-api-3.1.js
@@ -11,14 +11,8 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
   parse(joiSpec, definitions = {}, level = 0) {
     const schema = super.parse(joiSpec, definitions, level)
 
-    if (!_.isEmpty(joiSpec.metas)) {
-      _.each(joiSpec.metas, meta => {
-        _.each(meta, (value, key) => {
-          if (key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
-            schema[key] = value
-          }
-        })
-      })
+    if (!schema.$ref) {
+      this._copyMetasToSchema(joiSpec, schema)
     }
 
     if (level === 0 && !_.isEmpty(definitions)) {
@@ -31,6 +25,26 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
 
   _getLocalSchemaBasePath() {
     return '#/components/schemas'
+  }
+
+  _copyMetasToSchema(joiSpec, schema) {
+    if (!_.isEmpty(joiSpec.metas)) {
+      _.each(joiSpec.metas, meta => {
+        _.each(meta, (value, key) => {
+          if (key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
+            schema[key] = value
+          }
+        })
+      })
+    }
+  }
+
+  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
+    this._copyMetasToSchema(joiSpec, schema)
+    definitions[schemaId] = schema
+    return {
+      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
+    }
   }
 }
 

--- a/lib/parsers/open-api-3.1.js
+++ b/lib/parsers/open-api-3.1.js
@@ -11,10 +11,6 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
   parse(joiSpec, definitions = {}, level = 0) {
     const schema = super.parse(joiSpec, definitions, level)
 
-    if (!schema.$ref) {
-      this._copyMetasToSchema(joiSpec, schema)
-    }
-
     if (level === 0 && !_.isEmpty(definitions)) {
       schema.schemas = definitions
     }
@@ -36,14 +32,6 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
           }
         })
       })
-    }
-  }
-
-  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
-    this._copyMetasToSchema(joiSpec, schema)
-    definitions[schemaId] = schema
-    return {
-      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
     }
   }
 }

--- a/lib/parsers/open-api.js
+++ b/lib/parsers/open-api.js
@@ -5,41 +5,41 @@ function isKnownMetaKey(key) {
   return key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly'
 }
 
-const knownKeys = new Set([
-  '$ref',
-  'title',
-  'multipleOf',
-  'maximum',
-  'exclusiveMaximum',
-  'minimum',
-  'exclusiveMinimum',
-  'maxLength',
-  'minLength',
-  'pattern',
-  'maxItems',
-  'minItems',
-  'uniqueItems',
-  'maxProperties',
-  'minProperties',
-  'required',
-  'enum',
-  'description',
-  'format',
-  'default',
-  'type',
-
-  'allOf',
-  'oneOf',
-  'anyOf',
-  'not',
-  'items',
-  'properties',
-  'additionalProperties',
-
-  'example',
-  'nullable'
-])
 function isKnownKey(key) {
+  const knownKeys = new Set([
+    '$ref',
+    'title',
+    'multipleOf',
+    'maximum',
+    'exclusiveMaximum',
+    'minimum',
+    'exclusiveMinimum',
+    'maxLength',
+    'minLength',
+    'pattern',
+    'maxItems',
+    'minItems',
+    'uniqueItems',
+    'maxProperties',
+    'minProperties',
+    'required',
+    'enum',
+    'description',
+    'format',
+    'default',
+    'type',
+
+    'allOf',
+    'oneOf',
+    'anyOf',
+    'not',
+    'items',
+    'properties',
+    'additionalProperties',
+
+    'example',
+    'nullable'
+  ])
   return knownKeys.has(key) || isKnownMetaKey(key)
 }
 

--- a/lib/parsers/open-api.js
+++ b/lib/parsers/open-api.js
@@ -1,47 +1,6 @@
 const _ = require('lodash')
 const JoiJsonSchemaParser = require('./json-draft-04')
 
-function isKnownMetaKey(key) {
-  return key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly'
-}
-
-function isKnownKey(key) {
-  const knownKeys = new Set([
-    '$ref',
-    'title',
-    'multipleOf',
-    'maximum',
-    'exclusiveMaximum',
-    'minimum',
-    'exclusiveMinimum',
-    'maxLength',
-    'minLength',
-    'pattern',
-    'maxItems',
-    'minItems',
-    'uniqueItems',
-    'maxProperties',
-    'minProperties',
-    'required',
-    'enum',
-    'description',
-    'format',
-    'default',
-    'type',
-
-    'allOf',
-    'oneOf',
-    'anyOf',
-    'not',
-    'items',
-    'properties',
-    'additionalProperties',
-
-    'example',
-    'nullable'
-  ])
-  return knownKeys.has(key) || isKnownMetaKey(key)
-}
 
 class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
   constructor(opts = {}) {
@@ -126,17 +85,51 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
     }
   }
 
-  _copyMetasToSchema(joiSpec, schema) {
-    if (!_.isEmpty(joiSpec.metas)) {
-      _.each(joiSpec.metas, meta => {
-        _.each(meta, (value, key) => {
-          if (isKnownMetaKey(key)) {
-            schema[key] = value
-          }
-        })
-      })
-    }
+  _isKnownMetaKey(key) {
+    return isKnownMetaKey(key)
   }
+}
+
+function isKnownMetaKey(key) {
+  return key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly'
+}
+
+function isKnownKey(key) {
+  const knownKeys = new Set([
+    '$ref',
+    'title',
+    'multipleOf',
+    'maximum',
+    'exclusiveMaximum',
+    'minimum',
+    'exclusiveMinimum',
+    'maxLength',
+    'minLength',
+    'pattern',
+    'maxItems',
+    'minItems',
+    'uniqueItems',
+    'maxProperties',
+    'minProperties',
+    'required',
+    'enum',
+    'description',
+    'format',
+    'default',
+    'type',
+
+    'allOf',
+    'oneOf',
+    'anyOf',
+    'not',
+    'items',
+    'properties',
+    'additionalProperties',
+
+    'example',
+    'nullable'
+  ])
+  return knownKeys.has(key) || isKnownMetaKey(key)
 }
 
 module.exports = JoiOpenApiSchemaParser

--- a/lib/parsers/open-api.js
+++ b/lib/parsers/open-api.js
@@ -1,6 +1,48 @@
 const _ = require('lodash')
 const JoiJsonSchemaParser = require('./json-draft-04')
 
+function isKnownMetaKey(key) {
+  return key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly'
+}
+
+const knownKeys = new Set([
+  '$ref',
+  'title',
+  'multipleOf',
+  'maximum',
+  'exclusiveMaximum',
+  'minimum',
+  'exclusiveMinimum',
+  'maxLength',
+  'minLength',
+  'pattern',
+  'maxItems',
+  'minItems',
+  'uniqueItems',
+  'maxProperties',
+  'minProperties',
+  'required',
+  'enum',
+  'description',
+  'format',
+  'default',
+  'type',
+
+  'allOf',
+  'oneOf',
+  'anyOf',
+  'not',
+  'items',
+  'properties',
+  'additionalProperties',
+
+  'example',
+  'nullable'
+])
+function isKnownKey(key) {
+  return knownKeys.has(key) || isKnownMetaKey(key)
+}
+
 class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
   constructor(opts = {}) {
     super(_.merge({
@@ -16,44 +58,7 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
 
   parse(joiSpec, definitions = {}, level = 0) {
     const fullSchema = super.parse(joiSpec, definitions, level)
-    const schema = _.pick(fullSchema, [
-      '$ref',
-      'title',
-      'multipleOf',
-      'maximum',
-      'exclusiveMaximum',
-      'minimum',
-      'exclusiveMinimum',
-      'maxLength',
-      'minLength',
-      'pattern',
-      'maxItems',
-      'minItems',
-      'uniqueItems',
-      'maxProperties',
-      'minProperties',
-      'required',
-      'enum',
-      'description',
-      'format',
-      'default',
-      'type',
-
-      'allOf',
-      'oneOf',
-      'anyOf',
-      'not',
-      'items',
-      'properties',
-      'additionalProperties',
-
-      'example',
-      'nullable'
-    ])
-
-    if (!schema.$ref) {
-      this._copyMetasToSchema(joiSpec, schema)
-    }
+    const schema = _.pickBy(fullSchema, (value, key) => isKnownKey(key))
 
     if (level === 0 && !_.isEmpty(definitions)) {
       schema.schemas = definitions
@@ -125,19 +130,11 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
     if (!_.isEmpty(joiSpec.metas)) {
       _.each(joiSpec.metas, meta => {
         _.each(meta, (value, key) => {
-          if (key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
+          if (isKnownMetaKey(key)) {
             schema[key] = value
           }
         })
       })
-    }
-  }
-
-  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
-    this._copyMetasToSchema(joiSpec, schema)
-    definitions[schemaId] = schema
-    return {
-      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
     }
   }
 }

--- a/lib/parsers/open-api.js
+++ b/lib/parsers/open-api.js
@@ -51,14 +51,8 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
       'nullable'
     ])
 
-    if (!_.isEmpty(joiSpec.metas)) {
-      _.each(joiSpec.metas, meta => {
-        _.each(meta, (value, key) => {
-          if (key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
-            schema[key] = value
-          }
-        })
-      })
+    if (!schema.$ref) {
+      this._copyMetasToSchema(joiSpec, schema)
     }
 
     if (level === 0 && !_.isEmpty(definitions)) {
@@ -124,6 +118,26 @@ class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
       })
 
       delete fieldSchema.type
+    }
+  }
+
+  _copyMetasToSchema(joiSpec, schema) {
+    if (!_.isEmpty(joiSpec.metas)) {
+      _.each(joiSpec.metas, meta => {
+        _.each(meta, (value, key) => {
+          if (key.startsWith('x-') || key === 'deprecated' || key === 'readOnly' || key === 'writeOnly') {
+            schema[key] = value
+          }
+        })
+      })
+    }
+  }
+
+  _moveSchemaToDefinitions(schema, joiSpec, definitions, schemaId) {
+    this._copyMetasToSchema(joiSpec, schema)
+    definitions[schemaId] = schema
+    return {
+      $ref: `${this._getLocalSchemaBasePath()}/${schemaId}`
     }
   }
 }

--- a/lib/parsers/open-api.js
+++ b/lib/parsers/open-api.js
@@ -1,7 +1,6 @@
 const _ = require('lodash')
 const JoiJsonSchemaParser = require('./json-draft-04')
 
-
 class JoiOpenApiSchemaParser extends JoiJsonSchemaParser {
   constructor(opts = {}) {
     super(_.merge({

--- a/outputs-conversion/any/id_with_meta.json
+++ b/outputs-conversion/any/id_with_meta.json
@@ -1,0 +1,17 @@
+{
+  "type": "any",
+  "flags": {
+    "id": "person"
+  },
+  "metas": [
+    {
+      "x-expandable": true,
+      "x-lookup": "name",
+      "x-supported-lang": ["zh-CN", "en-US"],
+      "deprecated": true,
+      "readOnly": false,
+      "writeOnly": true,
+      "z-ignore": true
+    }
+  ]
+}

--- a/outputs-parsers/json-draft-04/any/id_with_meta.json
+++ b/outputs-parsers/json-draft-04/any/id_with_meta.json
@@ -1,0 +1,8 @@
+{
+  "$ref": "#/definitions/person",
+  "definitions": {
+    "person": {
+      "type": ["array", "boolean", "number", "object", "string", "null"]
+    }
+  }
+}

--- a/outputs-parsers/json-draft-2019-09/any/id_with_meta.json
+++ b/outputs-parsers/json-draft-2019-09/any/id_with_meta.json
@@ -1,0 +1,11 @@
+{
+  "$ref": "#/$defs/person",
+  "$defs": {
+    "person": {
+      "type": ["array", "boolean", "number", "object", "string", "null"],
+      "deprecated": true,
+      "readOnly": false,
+      "writeOnly": true
+    }
+  }
+}

--- a/outputs-parsers/json/any/id_with_meta.json
+++ b/outputs-parsers/json/any/id_with_meta.json
@@ -1,0 +1,15 @@
+{
+  "$ref": "#/$defs/person",
+  "$defs": {
+    "person": {
+      "type": [
+        "array",
+        "boolean",
+        "number",
+        "object",
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/outputs-parsers/open-api-3.1/any/id_with_meta.json
+++ b/outputs-parsers/open-api-3.1/any/id_with_meta.json
@@ -1,0 +1,21 @@
+{
+  "$ref": "#/components/schemas/person",
+  "schemas": {
+    "person": {
+      "type": [
+        "array",
+        "boolean",
+        "number",
+        "object",
+        "string",
+        "null"
+      ],
+      "deprecated": true,
+      "x-expandable": true,
+      "x-lookup": "name",
+      "x-supported-lang": ["zh-CN", "en-US"],
+      "readOnly": false,
+      "writeOnly": true
+    }
+  }
+}

--- a/outputs-parsers/open-api/any/id_with_meta.json
+++ b/outputs-parsers/open-api/any/id_with_meta.json
@@ -1,0 +1,32 @@
+{
+  "$ref": "#/components/schemas/person",
+  "schemas": {
+    "person": {
+      "nullable": true,
+      "anyOf": [
+        {
+          "items": {},
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "deprecated": true,
+      "x-expandable": true,
+      "x-lookup": "name",
+      "x-supported-lang": ["zh-CN", "en-US"],
+      "readOnly": false,
+      "writeOnly": true
+    }
+  }
+}


### PR DESCRIPTION
I would like to update a specific piece of behaviour.  Given the following Joi schema description:

```json
{
  "type": "any",
  "flags": {
    "id": "person"
  },
  "metas": [
    {
      "x-expandable": true,
      "x-lookup": "name",
      "x-supported-lang": ["zh-CN", "en-US"],
      "deprecated": true,
      "readOnly": false,
      "writeOnly": true,
      "z-ignore": true
    }
  ]
}

```

We can get the following open api flavoured JSON Schema (note: `deprecated` and other `x-` attrs are copied to the `schemas` collection):

```json
{
  "$ref": "#/components/schemas/person",
  "schemas": {
    "person": {
      "nullable": true,
      "anyOf": [
        {
          "items": {},
          "type": "array"
        },
        {
          "type": "boolean"
        },
        {
          "type": "number"
        },
        {
          "type": "object"
        },
        {
          "type": "string"
        }
      ],
      "deprecated": true,
      "x-expandable": true,
      "x-lookup": "name",
      "x-supported-lang": ["zh-CN", "en-US"],
      "readOnly": false,
      "writeOnly": true
    }
  }
}
```

Current behaviour is that these attrs are "left behind" on the `$ref` object like:

```json
{
  "$ref": "#/components/schemas/person",
  "deprecated": true,
  "x-expandable": true,
  "x-lookup": "name",
  "x-supported-lang": ["zh-CN", "en-US"],
  "readOnly": false,
  "writeOnly": true
  "schemas": {
    "person": {
      "nullable": true,
      "anyOf": [
        {
          "items": {},
          "type": "array"
        },
        {
          "type": "boolean"
        },
        {
          "type": "number"
        },
        {
          "type": "object"
        },
        {
          "type": "string"
        }
      ],
    }
  }
}
```