### PR TITLE
Allow schemas other than objects in pattern properties

### DIFF
--- a/fixtures-conversion/base/object.js
+++ b/fixtures-conversion/base/object.js
@@ -42,7 +42,8 @@ module.exports = function (joi) {
           .string()
           .allow('', null)
           .required()
-      })),
+      }))
+      .pattern(/a/, joi.array().items(joi.string())),
     unknown_false: joi.object().unknown(false),
     unknown_true: joi.object().unknown(true)
   }

--- a/fixtures-conversion/v13/object.js
+++ b/fixtures-conversion/v13/object.js
@@ -38,7 +38,8 @@ module.exports = function (joi) {
           .string()
           .allow('', null)
           .required()
-      })),
+      }))
+      .pattern(/a/, joi.array().items(joi.string())),
     unknown_false: joi.object().unknown(false),
     unknown_true: joi.object().unknown(true)
   }

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -304,23 +304,7 @@ class JoiJsonSchemaParser {
           return
         }
 
-        schema.properties[patternObj.regex] = {
-          type: patternObj.rule.type,
-          properties: {}
-        }
-        schema.properties[patternObj.regex].required = []
-
-        const childKeys = patternObj.rule.keys || patternObj.rule.children
-        schema.properties[patternObj.regex].additionalProperties = this._getUnknown(patternObj.rule)
-
-        _.each(childKeys, (ruleObj, key) => {
-          schema.properties[patternObj.regex].properties[key] = this.parse(ruleObj, definitions, level + 1)
-
-          if (this._isRequired(ruleObj)) {
-            schema.properties[patternObj.regex].required.push(key)
-          }
-        })
-
+        schema.properties[patternObj.regex] = this.parse(patternObj.rule, definitions, level + 1)
         schema.patternProperties = schema.patternProperties || {}
 
         let regexString = patternObj.regex

--- a/outputs-conversion/object/pattern.json
+++ b/outputs-conversion/object/pattern.json
@@ -24,6 +24,17 @@
           }
         }
       }
+    },
+    {
+      "regex": "/a/",
+      "rule": {
+        "type": "array",
+        "items": [
+          {
+            "type": "string"
+          }
+        ]
+      }
     }
   ]
 }

--- a/outputs-parsers/json-draft-04/object/pattern.json
+++ b/outputs-parsers/json-draft-04/object/pattern.json
@@ -19,6 +19,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "/a/": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,
@@ -41,6 +47,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "a": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/outputs-parsers/json-draft-2019-09/object/pattern.json
+++ b/outputs-parsers/json-draft-2019-09/object/pattern.json
@@ -19,6 +19,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "/a/": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,
@@ -41,6 +47,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "a": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/outputs-parsers/json/object/pattern.json
+++ b/outputs-parsers/json/object/pattern.json
@@ -19,6 +19,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "/a/": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,
@@ -41,6 +47,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "a": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/outputs-parsers/open-api-3.1/object/pattern.json
+++ b/outputs-parsers/open-api-3.1/object/pattern.json
@@ -19,6 +19,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "/a/": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,
@@ -41,6 +47,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "a": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/outputs-parsers/open-api/object/pattern.json
+++ b/outputs-parsers/open-api/object/pattern.json
@@ -17,6 +17,12 @@
         "name"
       ],
       "additionalProperties": false
+    },
+    "/a/": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
When defining a schema with Joi.object().pattern(//, joi.any()), that final `any` was assumed to be an object and would behave in weird ways if it wasn't. Since it can be any valid schema it make sense to do a recursive call to parse those schemas.

Fixes #55 