### PR TITLE
Fix removal of metas from `joi.alternatives().conditional`

### DIFF
--- a/fixtures-baseline/alternatives.js
+++ b/fixtures-baseline/alternatives.js
@@ -8,7 +8,7 @@ module.exports = function (joi) {
     conditional_schema: joi.alternatives().conditional(joi.string(), {
       then: joi.string().not('', null),
       otherwise: joi.number().greater(0)
-    }).meta({ 'if-style': false }),
+    }).meta({ 'if-style': false }).meta({ 'x-custom': 'test' }),
     conditional_switch: joi.alternatives().conditional('height', {
       switch: [
         { is: 0, then: joi.link('#unifiedString') },

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -602,7 +602,7 @@ class JoiJsonSchemaParser {
 
     let ifThenStyle = this._isIfThenElseSupported()
     const styleSetting = _.remove(joiSpec.metas, (meta) => {
-      return meta['if-style'] != null
+      return typeof meta['if-style'] !== 'undefined'
     })
 
     if (ifThenStyle && styleSetting.length > 0 && styleSetting[0]['if-style'] === false) {

--- a/lib/parsers/json.js
+++ b/lib/parsers/json.js
@@ -602,7 +602,7 @@ class JoiJsonSchemaParser {
 
     let ifThenStyle = this._isIfThenElseSupported()
     const styleSetting = _.remove(joiSpec.metas, (meta) => {
-      return typeof meta['if-style'] !== undefined
+      return meta['if-style'] != null
     })
 
     if (ifThenStyle && styleSetting.length > 0 && styleSetting[0]['if-style'] === false) {

--- a/outputs-baseline/alternatives/conditional_schema.json
+++ b/outputs-baseline/alternatives/conditional_schema.json
@@ -3,6 +3,9 @@
   "metas": [
     {
       "if-style": false
+    },
+    {
+      "x-custom": "test"
     }
   ],
   "matches": [

--- a/outputs-parsers/open-api-3.1/alternatives/conditional_schema.json
+++ b/outputs-parsers/open-api-3.1/alternatives/conditional_schema.json
@@ -1,4 +1,5 @@
 {
+  "x-custom": "test",
   "allOf": [
     {
       "anyOf": [

--- a/outputs-parsers/open-api/alternatives/conditional_schema.json
+++ b/outputs-parsers/open-api/alternatives/conditional_schema.json
@@ -1,4 +1,5 @@
 {
+  "x-custom": "test",
   "allOf": [
     {
       "anyOf": [


### PR DESCRIPTION
The current logic for removing meta from conditional alternatives will always remove all alternatives. Proposed fix updates the logic to remove `typeof` as this will always return a string and rather check for non-nullish values instead.